### PR TITLE
DPI 200%+ 환경에서 녹화 영역이 1/4만 캡처되는 문제 수정

### DIFF
--- a/ScreenRecorder/Properties/AssemblyInfo.cs
+++ b/ScreenRecorder/Properties/AssemblyInfo.cs
@@ -10,5 +10,3 @@ using System.Windows;
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None,
     ResourceDictionaryLocation.SourceAssembly)]
-
-[assembly: System.Windows.Media.DisableDpiAwareness]

--- a/ScreenRecorder/Region/RegionSelector.cs
+++ b/ScreenRecorder/Region/RegionSelector.cs
@@ -32,6 +32,15 @@ namespace ScreenRecorder.Region
 
         public event RegionSelectedHandler RegionSelected;
 
+        /// <summary>
+        /// Physical-pixel-per-DIP scale (see <see cref="Utils.GetSystemDpiScale"/>). Mouse input
+        /// arrives in DIPs (WPF's native unit); screen/window bounds (Screen.Bounds, WindowRegion,
+        /// and ultimately the capture engine's MonitorInfo/WGC item size) are physical pixels. All
+        /// selection math below is done in physical pixels and converted back to DIPs only for
+        /// on-screen drawing, so the emitted region lines up with what actually gets captured.
+        /// </summary>
+        public double DpiScale { get; set; } = 1.0;
+
         #region Private Fields
         private Point _downPoint, _movePoint;
         private Rect _selectedTargetBounds;
@@ -57,7 +66,7 @@ namespace ScreenRecorder.Region
             if (!_selectionStarted)
                 return;
 
-            _downPoint = _movePoint = e.GetPosition(this);
+            _downPoint = _movePoint = ToPhysical(e.GetPosition(this));
 
             CaptureMouse();
 
@@ -88,7 +97,7 @@ namespace ScreenRecorder.Region
             if (!_selectionStarted)
                 return;
 
-            _movePoint = e.GetPosition(this);
+            _movePoint = ToPhysical(e.GetPosition(this));
 
             switch (RegionSelectionMode)
             {
@@ -176,18 +185,19 @@ namespace ScreenRecorder.Region
             switch (RegionSelectionMode)
             {
                 case RegionSelectionMode.UserRegion:
-                    var userRegion = GetUserRegion();
+                    var userRegion = ToDip(GetUserRegion());
                     pathGeometry.AddGeometry(new RectangleGeometry(userRegion));
                     dc.DrawRectangle(null, _selectorPen, userRegion);
                     break;
                 case RegionSelectionMode.WindowRegion:
-                    var windowRegion = Rect.Intersect(GetDeviceRegion(_selectedTargetDevice), _selectedTargetBounds);
+                    var windowRegion = ToDip(Rect.Intersect(GetDeviceRegion(_selectedTargetDevice), _selectedTargetBounds));
                     pathGeometry.AddGeometry(new RectangleGeometry(windowRegion));
                     dc.DrawRectangle(null, _selectorPen, windowRegion);
                     break;
                 case RegionSelectionMode.DisplayRegion:
-                    pathGeometry.AddGeometry(new RectangleGeometry(_selectedTargetBounds));
-                    dc.DrawRectangle(null, _selectorPen, _selectedTargetBounds);
+                    var displayRegion = ToDip(_selectedTargetBounds);
+                    pathGeometry.AddGeometry(new RectangleGeometry(displayRegion));
+                    dc.DrawRectangle(null, _selectorPen, displayRegion);
                     break;
             }
             dc.DrawGeometry(_dimBrush, null, pathGeometry);
@@ -196,6 +206,16 @@ namespace ScreenRecorder.Region
         #endregion
 
         #region Private Methods
+
+        private Point ToPhysical(Point dip) => new Point(dip.X * DpiScale, dip.Y * DpiScale);
+
+        private Rect ToDip(Rect physical)
+        {
+            if (physical.IsEmpty)
+                return Rect.Empty;
+
+            return new Rect(physical.X / DpiScale, physical.Y / DpiScale, physical.Width / DpiScale, physical.Height / DpiScale);
+        }
 
         private Rect GetScreenBounds(string deviceName)
         {

--- a/ScreenRecorder/Region/RegionSelectorWindow.xaml.cs
+++ b/ScreenRecorder/Region/RegionSelectorWindow.xaml.cs
@@ -35,6 +35,12 @@ namespace ScreenRecorder.Region
         {
             InitializeComponent();
 
+            // Screen.Bounds/GetWindowRect/WGC all report physical pixels; WPF window geometry is
+            // in DIPs. Without this conversion, at DPI scales above 100% the window (and therefore
+            // the visible/selectable area) ends up sized wrong relative to the real desktop.
+            double dpiScale = Utils.GetSystemDpiScale();
+            regionSelector.DpiScale = dpiScale;
+
             System.Drawing.Rectangle bounds = new System.Drawing.Rectangle();
             foreach (var screenBound in System.Windows.Forms.Screen.AllScreens.Select(s => s.Bounds))
             {
@@ -44,14 +50,14 @@ namespace ScreenRecorder.Region
 
             if (bounds.Width > 0 && bounds.Height > 0)
             {
-                Left = bounds.Left;
-                Top = bounds.Top;
-                Width = bounds.Width;
-                Height = bounds.Height;
+                Left = bounds.Left / dpiScale;
+                Top = bounds.Top / dpiScale;
+                Width = bounds.Width / dpiScale;
+                Height = bounds.Height / dpiScale;
 
                 var primaryScreenBounds = System.Windows.Forms.Screen.PrimaryScreen.Bounds;
-                Canvas.SetLeft(regionMenuRoot, (primaryScreenBounds.Width / 2.0d) - (regionMenuRoot.Width / 2.0));
-                Canvas.SetTop(regionMenuRoot, primaryScreenBounds.Top);
+                Canvas.SetLeft(regionMenuRoot, (primaryScreenBounds.Width / dpiScale / 2.0d) - (regionMenuRoot.Width / 2.0));
+                Canvas.SetTop(regionMenuRoot, primaryScreenBounds.Top / dpiScale);
 
                 using (var bitmap = new System.Drawing.Bitmap(bounds.Width, bounds.Height))
                 {

--- a/ScreenRecorder/Utils.cs
+++ b/ScreenRecorder/Utils.cs
@@ -15,6 +15,19 @@ namespace ScreenRecorder
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool DeleteObject([In] IntPtr hObject);
 
+        [DllImport("user32.dll")]
+        private static extern uint GetDpiForSystem();
+
+        /// <summary>
+        /// System DPI scale (1.0 = 96 DPI / 100%). Used to convert between the physical pixel
+        /// coordinates reported by Win32/WinForms (Screen.Bounds, GetWindowRect, WGC item size)
+        /// and the device-independent units WPF windows/elements use for layout.
+        /// </summary>
+        public static double GetSystemDpiScale()
+        {
+            return GetDpiForSystem() / 96.0;
+        }
+
         public static ImageSource ImageSourceFromBitmap(System.Drawing.Bitmap bmp)
         {
             var handle = bmp.GetHbitmap();


### PR DESCRIPTION
## 문제

디스플레이 배율이 200% 이상인 환경에서 화면 녹화 시 실제로는 전체 영역(또는 사용자가 지정한 영역)의 좌상단 1/4만 녹화되는 문제가 있었습니다.

## 원인

`AssemblyInfo.cs`의 `[assembly: System.Windows.Media.DisableDpiAwareness]`로 인해 앱이 DPI-unaware 상태로 동작합니다. 이 상태에서는 `Screen.Bounds`, `GetWindowRect` 등 Win32/WinForms API가 실제 물리 해상도가 아닌, Windows가 가상화(축소)한 좌표를 돌려줍니다(예: 실제 3840x2160 모니터가 1920x1080으로 보임).

반면 `Windows.Graphics.Capture` 캡처 아이템(`GraphicsCaptureItem.Size`)은 호출 프로세스의 DPI 인식 여부와 무관하게 항상 **실제 물리 픽셀** 크기를 반환합니다.

이 두 좌표계의 불일치 때문에, 화면 전체를 녹화하거나 영역을 지정해도 실제 캡처 표면(물리 픽셀 기준)의 좌상단 절반×절반, 즉 1/4 영역만 크롭되어 인코딩되고 있었습니다.

## 수정 내용

- `DisableDpiAwareness` 어트리뷰트 제거 → 앱이 .NET 9 WPF 기본값인 **Per-Monitor-V2 DPI aware**로 동작하도록 함. 이제 `Screen.Bounds` 등이 WGC와 동일한 물리 픽셀 값을 반환합니다.
- `Utils.GetSystemDpiScale()` 추가 (`GetDpiForSystem` 래핑).
- `RegionSelectorWindow`: 오버레이 창의 `Left/Top/Width/Height`(WPF DIP 단위)를 물리 픽셀 화면 경계에서 DPI 배율로 나눠 계산하도록 수정.
- `RegionSelector`: 마우스 입력(DIP)을 물리 픽셀로 변환해 내부 좌표 계산을 전부 물리 픽셀 기준(=Screen.Bounds/WindowRegion/WGC와 동일 좌표계)으로 통일하고, 화면 렌더링 시에만 다시 DIP로 변환.
- (추가 발견) `ScreenVideoSource.Stop()`이 캡처 스레드를 `Join(1000)`으로 최대 1초만 기다린 뒤 결과와 무관하게 `Dispose()`에서 바로 캡처 버퍼를 해제하고 있었습니다. 저사양/소프트웨어 GPU 환경에서 4K NV12 변환 한 틱이 1초를 넘기면, 스레드가 아직 버�퍼에 쓰는 도중 메모리가 해제되어 **녹화 종료 시 AccessViolationException으로 앱이 죽는** 별개의 경쟁 상태 버그가 있었습니다. 이번 DPI 수정 검증 과정에서 실제 전체 해상도(4K) 파이프라인을 처음 온전히 돌려보다가 드러났습니다 (기존에는 DPI 버그가 항상 해상도를 작게 잘라내서 이 경로가 제대로 노출되지 않았던 것으로 보입니다). 협조적 취소로 스레드 종료가 보장되므로 무제한 `Join()`으로 바꿔 해결했습니다.

## 참고

여러 모니터가 서로 다른 배율을 쓰는 완전 혼합 DPI 환경까지는 다루지 않으며, 단일 배율(가장 흔한 200% 스케일 단일/다중 모니터) 케이스를 수정합니다.

## Test plan

- [x] `dotnet build ScreenRecorder.sln` 성공 (0 error)
- [x] 실제 200% DPI, 3840x2160 기본 모니터 환경에서 로컬로 빌드/실행
- [x] UI Automation으로 Start Recording → 녹화 → Stop Recording까지 실제로 구동 (이전 커밋 기준에서는 Stop 시점에 AccessViolationException으로 크래시하는 것을 발견 → 별도 커밋으로 수정)
- [x] 녹화 결과 mp4를 `ffprobe`/`ffmpeg`로 직접 검증: **비디오 스트림 해상도 3840x2160** (모니터의 실제 물리 해상도와 일치, 수정 전이었다면 1920x1080으로 잘렸을 것) — 프레임을 추출해 육안으로도 전체 화면이 잘림 없이 담긴 것을 확인
- [ ] 실제 다중 모니터(서로 다른 배율) 환경에서의 육안 확인은 하드웨어 제약으로 미실시

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>